### PR TITLE
Improve Core types in preparation for ts v4.7.4

### DIFF
--- a/packages/core/http/core-http-router-server-internal/src/versioned_router/core_versioned_route.ts
+++ b/packages/core/http/core-http-router-server-internal/src/versioned_router/core_versioned_route.ts
@@ -161,9 +161,9 @@ export class CoreVersionedRoute implements VersionedRoute {
     ) {
       try {
         const { body, params, query } = validate(req, validation.request, handler.options.version);
-        (req as Mutable<KibanaRequest>).body = body;
-        (req as Mutable<KibanaRequest>).params = params;
-        (req as Mutable<KibanaRequest>).query = query;
+        req.body = body;
+        req.params = params;
+        req.query = query;
       } catch (e) {
         return res.badRequest({
           body: e.message,
@@ -171,9 +171,9 @@ export class CoreVersionedRoute implements VersionedRoute {
       }
     } else {
       // Preserve behavior of not passing through unvalidated data
-      (req as Mutable<KibanaRequest>).body = {};
-      (req as Mutable<KibanaRequest>).params = {};
-      (req as Mutable<KibanaRequest>).query = {};
+      req.body = {};
+      req.params = {};
+      req.query = {};
     }
 
     const response = await handler.fn(ctx, req, res);

--- a/packages/core/http/core-http-router-server-internal/src/versioned_router/route_version_utils.ts
+++ b/packages/core/http/core-http-router-server-internal/src/versioned_router/route_version_utils.ts
@@ -52,7 +52,9 @@ type KibanaRequestWithQueryVersion = KibanaRequest<
   { [ELASTIC_HTTP_VERSION_QUERY_PARAM]: unknown }
 >;
 
-export function hasQueryVersion(request: KibanaRequest): request is KibanaRequestWithQueryVersion {
+export function hasQueryVersion(
+  request: Mutable<KibanaRequest>
+): request is Mutable<KibanaRequestWithQueryVersion> {
   return isObject(request.query) && ELASTIC_HTTP_VERSION_QUERY_PARAM in request.query;
 }
 export function removeQueryVersion(request: Mutable<KibanaRequestWithQueryVersion>): void {


### PR DESCRIPTION
## Summary

Improves Core types for ts v4.7.4


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
