### PR TITLE
- Fix cases test typing

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/routes/api/register_routes.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/register_routes.test.ts
@@ -11,7 +11,7 @@ import { httpServerMock, httpServiceMock, loggingSystemMock } from '@kbn/core/se
 
 import { usageCollectionPluginMock } from '@kbn/usage-collection-plugin/server/mocks';
 
-import type { CasesRouter } from '../../types';
+import type { CasesRequestHandlerContext, CasesRouter } from '../../types';
 import { createCasesRoute } from './create_cases_route';
 import { registerRoutes } from './register_routes';
 import type { CaseRoute } from './types';
@@ -80,12 +80,12 @@ describe('registerRoutes', () => {
     const simulateRequest = async ({
       method,
       path,
-      context = { cases: {} },
+      context = { cases: {} } as CasesRequestHandlerContext,
       headers = {},
     }: {
       method: keyof Pick<CasesRouter, 'get' | 'post'>;
       path: string;
-      context?: Record<string, unknown>;
+      context?: CasesRequestHandlerContext;
       headers?: Record<string, unknown>;
     }) => {
       const [, registeredRouteHandler] =
@@ -94,10 +94,11 @@ describe('registerRoutes', () => {
           return call[0].path === path;
         }) ?? [];
 
-      // @ts-expect-error upgrade typescript v5.4.5
+      if (!registeredRouteHandler) return;
+
       const result = await registeredRouteHandler(
-        // @ts-expect-error upgrade typescript v5.4.5
         context,
+        // @ts-ignore we don't need to pass a real request object here
         { headers },
         { customError, badRequest }
       );
@@ -321,7 +322,7 @@ describe('registerRoutes', () => {
       await simulateRequest({
         method: 'get',
         path: '/foo/{case_id}',
-        context: {},
+        context: {} as CasesRequestHandlerContext,
       });
 
       expect(badRequest).toBeCalledWith({


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



